### PR TITLE
Add support for musicFolderId and ifModifiedSince args in getIndexes()

### DIFF
--- a/subsonic-api/api/subsonic-api.api
+++ b/subsonic-api/api/subsonic-api.api
@@ -50,8 +50,8 @@ public abstract interface class dev/zt64/subsonic/api/SubsonicApi {
 	public abstract fun getDirectories (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun getDirectory (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun getGenres (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun getIndexes (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun getIndexes$default (Ldev/zt64/subsonic/api/SubsonicApi;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public abstract fun getIndexes (Ljava/lang/String;Lkotlin/time/Instant;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getIndexes$default (Ldev/zt64/subsonic/api/SubsonicApi;Ljava/lang/String;Lkotlin/time/Instant;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public abstract fun getInternetRadioStations (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun getLicense (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun getLyrics (Ldev/zt64/subsonic/api/model/Song;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -142,7 +142,7 @@ public final class dev/zt64/subsonic/api/SubsonicApi$DefaultImpls {
 	public static synthetic fun getAvatarUrl$default (Ldev/zt64/subsonic/api/SubsonicApi;Ljava/lang/String;ZILjava/lang/Object;)Ljava/lang/String;
 	public static synthetic fun getCoverArt$default (Ldev/zt64/subsonic/api/SubsonicApi;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static synthetic fun getCoverArtUrl$default (Ldev/zt64/subsonic/api/SubsonicApi;Ljava/lang/String;Ljava/lang/String;ZILjava/lang/Object;)Ljava/lang/String;
-	public static synthetic fun getIndexes$default (Ldev/zt64/subsonic/api/SubsonicApi;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun getIndexes$default (Ldev/zt64/subsonic/api/SubsonicApi;Ljava/lang/String;Lkotlin/time/Instant;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static synthetic fun getNewestPodcasts$default (Ldev/zt64/subsonic/api/SubsonicApi;ILkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static synthetic fun getPodcasts$default (Ldev/zt64/subsonic/api/SubsonicApi;ZLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static synthetic fun getRandomSongs$default (Ldev/zt64/subsonic/api/SubsonicApi;ILjava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;

--- a/subsonic-api/src/commonMain/kotlin/dev/zt64/subsonic/api/SubsonicApi.kt
+++ b/subsonic-api/src/commonMain/kotlin/dev/zt64/subsonic/api/SubsonicApi.kt
@@ -119,9 +119,13 @@ public interface SubsonicApi {
      * Get an indexed structure of all artists.
      *
      * @param musicFolderId Only return artists in the specified music folder
+     * @param ifModifiedSince Only return artists (and indexes) modified since this instant
      * @return Indexed artist list
      */
-    public suspend fun getIndexes(musicFolderId: String? = null): ArtistIndexes
+    public suspend fun getIndexes(
+        musicFolderId: String? = null,
+        ifModifiedSince: Instant? = null
+    ): ArtistIndexes
 
     /**
      * Get a listing of all files in a music directory. Not to be confused with [getDirectories]

--- a/subsonic-client/api/subsonic-client.api
+++ b/subsonic-client/api/subsonic-client.api
@@ -73,7 +73,7 @@ public final class dev/zt64/subsonic/client/SubsonicClient : dev/zt64/subsonic/a
 	public fun getDirectories (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getDirectory (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getGenres (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getIndexes (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getIndexes (Ljava/lang/String;Lkotlin/time/Instant;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getInternetRadioStations (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getLicense (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getLyrics (Ldev/zt64/subsonic/api/model/Song;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;

--- a/subsonic-client/src/commonMain/kotlin/dev/zt64/subsonic/api/SubsonicApiImpl.kt
+++ b/subsonic-client/src/commonMain/kotlin/dev/zt64/subsonic/api/SubsonicApiImpl.kt
@@ -199,8 +199,14 @@ internal class SubsonicApiImpl(
         return getBody("getMusicFolders")
     }
 
-    override suspend fun getIndexes(musicFolderId: String?): ArtistIndexes {
-        return getBody("getIndexes")
+    override suspend fun getIndexes(
+        musicFolderId: String?,
+        ifModifiedSince: Instant?
+    ): ArtistIndexes {
+        return getBody("getIndexes") {
+            parameter("musicFolderId", musicFolderId)
+            parameter("ifModifiedSince", ifModifiedSince?.toEpochMilliseconds())
+        }
     }
 
     override suspend fun getDirectory(id: String): Directory {

--- a/subsonic-client/src/commonTest/kotlin/dev/zt64/subsonic/client/test/LibraryTest.kt
+++ b/subsonic-client/src/commonTest/kotlin/dev/zt64/subsonic/client/test/LibraryTest.kt
@@ -3,6 +3,7 @@ package dev.zt64.subsonic.client.test
 import dev.zt64.subsonic.client.SubsonicClient
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
+import kotlin.time.Instant
 
 class LibraryTest {
     @Test
@@ -51,6 +52,38 @@ class LibraryTest {
             """.trimIndent()
         ) {
             getIndexes()
+        }
+    }
+
+    @Test
+    fun testGetIndexesIfModifiedSince() = runTest {
+        val since = Instant.fromEpochMilliseconds(1678943707000)
+
+        testEndpoint(
+            endpoint = "getIndexes",
+            response = """
+                "indexes": {
+                  "lastModified": 1678943707000,
+                  "ignoredArticles": "The An A Die Das Ein Eine Les Le La",
+                  "index": [
+                    {
+                      "name": "A",
+                      "artist": [
+                        {
+                          "id": "ar-1",
+                          "name": "Artist 1"
+                        }
+                      ]
+                    }
+                  ]
+                }
+            """.trimIndent(),
+            expectedParams = mapOf(
+                "musicFolderId" to "1",
+                "ifModifiedSince" to since.toEpochMilliseconds().toString()
+            )
+        ) {
+            getIndexes(musicFolderId = "1", ifModifiedSince = since)
         }
     }
 

--- a/subsonic-client/src/commonTest/kotlin/dev/zt64/subsonic/client/test/Util.kt
+++ b/subsonic-client/src/commonTest/kotlin/dev/zt64/subsonic/client/test/Util.kt
@@ -13,6 +13,7 @@ val username = env("SUBSONIC_USERNAME") ?: "abc"
 val password = env("SUBSONIC_PASSWORD") ?: "xyz"
 
 private val responses = mutableMapOf<String, String?>()
+private val expectedQueryParams = mutableMapOf<String, Map<String, String?>>()
 
 @OptIn(ExperimentalUuidApi::class)
 val client by lazy {
@@ -38,6 +39,13 @@ val client by lazy {
                 assertEquals(params["f"], "json")
 
                 val endpoint = req.url.segments.last()
+
+                val expected = expectedQueryParams[endpoint]
+                if (expected != null) {
+                    expected.forEach { (k, v) ->
+                        assertEquals(v, params[k])
+                    }
+                }
 
                 if (endpoint in responses) {
                     val content = responses[endpoint]
@@ -91,8 +99,10 @@ expect fun env(name: String): String?
 suspend fun <T> testEndpoint(
     endpoint: String,
     response: String? = null,
+    expectedParams: Map<String, String?> = emptyMap(),
     call: suspend SubsonicClient.() -> T
 ): T? {
     responses["$endpoint.view"] = response
+    expectedQueryParams["$endpoint.view"] = expectedParams
     return client.call().also { println(it) }
 }


### PR DESCRIPTION
Tested this in a music app I'm working on and Navidrome v0.61.2.

I needed ifModifiedSince support but I noticed musicFolderId was missing so I added that too and also added a unit test that verifies they're making it into the request.

Let me know if I've done anything wrong, I'm happy to clean it up.